### PR TITLE
Recode AltoMare

### DIFF
--- a/AltoMare/AltoMare.js
+++ b/AltoMare/AltoMare.js
@@ -1,0 +1,98 @@
+import ValidatorRegistry from "./ValidatorRegistry";
+import SchemaValidator from "./SchemaValidator";
+
+class AltoMare {
+    #schemas = new Map();
+    #templates = new Map();
+    #validator;
+    #registry;
+
+    constructor(mode = "silent") {
+        this.#registry = new ValidatorRegistry();
+        // must be called after registry, otherwise
+        this.checkParams(arguments, ["string"]);
+        this.#validator = new SchemaValidator(this.#registry, mode);
+    }
+
+    registerValidator(validators) {
+        this.checkParams(arguments, ["function"]);
+
+        if (Array.isArray(validators)) {
+            validators.forEach(validator => this.registerValidator(validator));
+            return;
+        }
+
+        Object.entries(validators).forEach(([name, validator]) => {
+            this.#registry.register(name, validator);
+        });
+    }
+
+    register(name, schema) {
+        this.checkParams(arguments, ["string", "object"]);
+        this.#schemas.set(name, schema);
+    }
+
+    registerFromTemplate(name, templateName, overrides = {}) {
+        this.checkParams(arguments, ["string", "string", "object"]);
+        const template = this.#templates.get(templateName);
+        if (!template) {
+            throw new Error(`Template '${templateName}' not found`);
+        }
+        this.register(name, { ...template, ...overrides });
+    }
+
+    validate(schemaName, data) {
+        this.checkParams(arguments, ["string", "object"]);
+        const schema = this.get(schemaName);
+        return this.#validator.validateSchema(schema, data, schemaName);
+    }
+
+    checkParams(args, types) {
+        if (!Array.isArray(types)) {
+            throw new Error("Both arguments must be arrays");
+        }
+
+        if (args.length !== types.length) {
+            throw new Error(`Expected ${types.length} parameters but got ${args.length}`);
+        }
+
+        for (let i = 0; i < args.length; i++) {
+            const typeValidator = this.#registry.getTypeValidator(types[i]);
+            if (!typeValidator) {
+                throw new Error(`Unknown type '${types[i]}'`);
+            }
+
+            if (!typeValidator(args[i])) {
+                throw new Error(`Parameter at index ${i} failed type validation. Expected ${types[i]}, got ${typeof args[i]}`);
+            }
+        }
+
+        return true;
+    }
+
+    get(name) {
+        this.checkParams(arguments, ["string"]);
+        const schema = this.#schemas.get(name);
+        if (!schema) {
+            throw new Error(`Schema '${name}' not found`);
+        }
+        return schema;
+    }
+
+    unregister(name) {
+        this.checkParams(arguments, ["string"]);
+        this.#schemas.delete(name);
+    }
+
+    loadTemplates(templateJson) {
+        this.checkParams(arguments, ["string"]);
+        try {
+            const templates = JSON.parse(templateJson);
+            this.#templates = new Map(Object.entries(templates));
+        } catch (error) {
+            throw new Error(`Failed to parse templates JSON: ${error.message}`);
+        }
+    }
+}
+
+export default AltoMare;

--- a/AltoMare/SchemaValidator.js
+++ b/AltoMare/SchemaValidator.js
@@ -1,0 +1,147 @@
+class SchemaValidator {
+    #registry;
+    #mode;
+
+    constructor(registry, mode) {
+        this.#registry = registry;
+        this.#mode = mode;
+    }
+
+    validateSchema(schema, data, schemaPath) {
+        const errors = [];
+
+        errors.push(...this.validateRequired(data, schema, schemaPath));
+        errors.push(...this.validateProperties(data, schema, schemaPath));
+
+        if (errors.length === 0) return true;
+
+        if (this.#mode === "debug") {
+            console.error("Validation errors:", errors);
+        }
+        return false;
+    }
+
+    validateValue(value, rule, schemaPath) {
+        const errors = [];
+
+        if (value !== undefined) {
+            errors.push(...this.validateType(value, rule, schemaPath));
+            errors.push(...this.validateRules(value, rule, schemaPath));
+            if ((rule.items && Array.isArray(value)) || (rule.properties && typeof value === "object")) {
+                errors.push(...this.validateNested(value, rule, schemaPath));
+            }
+        }
+
+        return errors;
+    }
+
+    validateType(value, rule, schemaPath) {
+        const errors = [];
+        if (!rule.type) return errors;
+
+        const typeValidator = this.#registry.getTypeValidator(rule.type);
+        if (!typeValidator) {
+            errors.push({
+                path: schemaPath,
+                message: `Unknown type '${rule.type}'`,
+            });
+            return errors;
+        }
+
+        if (!typeValidator(value)) {
+            errors.push({
+                path: schemaPath,
+                message: `Type validation failed. Expected ${rule.type}, got ${typeof value}`,
+                value,
+            });
+        }
+
+        return errors;
+    }
+
+    validateRules(value, rule, schemaPath) {
+        const errors = [];
+        for (const [ruleName, ruleConfig] of Object.entries(rule)) {
+            if (["type", "required"].includes(ruleName)) {
+                continue;
+            }
+
+            const validator = this.#registry.getValidator(ruleName);
+            if (!validator) continue;
+
+            const ruleValue = ruleConfig?.value ?? ruleConfig;
+            const message = ruleConfig?.message;
+
+            if (!validator(value, ruleValue)) {
+                errors.push({
+                    path: schemaPath,
+                    message: message || `${ruleName} validation failed`,
+                    value,
+                });
+            }
+        }
+        return errors;
+    }
+
+    validateNested(value, rule, schemaPath) {
+        const errors = [];
+        if (rule.properties && value) {
+            errors.push(...this.validateSchema(rule.properties, value, schemaPath));
+        }
+
+        if (rule.items && Array.isArray(value)) {
+            value.forEach((item, index) => {
+                const itemSchemaPath = `${schemaPath}[${index}]`;
+                errors.push(...this.validateValue(item, rule.items, itemSchemaPath));
+            });
+        }
+
+        return errors;
+    }
+
+    validateRequired(data, schema, schemaPath) {
+        const errors = [];
+        const required = schema.requiredProperties || [];
+        const missing = required.find(key => !(key in data));
+        if (missing) {
+            errors.push({
+                path: schemaPath,
+                message: `Required property '${missing}' is missing`,
+                data,
+            });
+        }
+        return errors;
+    }
+
+    validateProperties(data, schema, schemaPath) {
+        const errors = [];
+
+        if (typeof data !== "object" || data === null || Array.isArray(data)) {
+            return errors;
+        }
+
+        const allowedKeys = Object.keys(schema).filter(key => key !== "requiredProperties");
+        const dataKeys = Object.keys(data);
+        const unknownKeys = dataKeys.filter(key => !allowedKeys.includes(key));
+
+        if (unknownKeys.length > 0) {
+            errors.push({
+                path: schemaPath,
+                message: `Unknown properties '${unknownKeys.join(", ")}' are not allowed`,
+                data,
+            });
+        }
+
+        for (const [key, rule] of Object.entries(schema)) {
+            if (key === "requiredProperties" || !(key in data)) continue;
+
+            const value = data[key];
+            const propertyPath = `${schemaPath}.${key}`;
+            errors.push(...this.validateValue(value, rule, propertyPath));
+        }
+
+        return errors;
+    }
+}
+
+export default SchemaValidator;

--- a/AltoMare/ValidatorRegistry.js
+++ b/AltoMare/ValidatorRegistry.js
@@ -1,0 +1,61 @@
+class ValidatorRegistry {
+    #validators = new Map();
+    #typeValidators = new Map();
+
+    constructor() {
+        this.initializeDefaultValidators();
+        this.initializeTypeValidators();
+    }
+
+    initializeDefaultValidators() {
+        this.register("enum", (value, enumValues) => enumValues.includes(value));
+        this.register("min", (value, minValue) => value >= minValue);
+        this.register("max", (value, maxValue) => value <= maxValue);
+        this.register("minLength", (value, minLength) => value.length >= minLength);
+        this.register("maxLength", (value, maxLength) => value.length <= maxLength);
+        this.register("pattern", (value, pattern) => new RegExp(pattern).test(value));
+    }
+
+    initializeTypeValidators() {
+        this.registerType("string", v => typeof v === "string");
+        this.registerType("number", v => typeof v === "number");
+        this.registerType("boolean", v => typeof v === "boolean");
+        this.registerType("object", v => v && typeof v === "object" && !Array.isArray(v));
+        this.registerType("array", Array.isArray);
+        this.registerType("null", v => v === null);
+        this.registerType("function", v => typeof v === "function");
+        this.registerType("any", () => true);
+    }
+
+    register(name, validator) {
+        if (typeof validator !== "function") {
+            throw new Error("Validator must be a function");
+        }
+        this.#validators.set(name, validator);
+    }
+
+    registerType(name, validator) {
+        if (typeof validator !== "function") {
+            throw new Error("Type validator must be a function");
+        }
+        this.#typeValidators.set(name, validator);
+    }
+
+    getValidator(name) {
+        return this.#validators.get(name);
+    }
+
+    getTypeValidator(name) {
+        return this.#typeValidators.get(name);
+    }
+
+    hasValidator(name) {
+        return this.#validators.has(name);
+    }
+
+    hasTypeValidator(name) {
+        return this.#typeValidators.has(name);
+    }
+}
+
+export default ValidatorRegistry;

--- a/test/AltoMare.test.js
+++ b/test/AltoMare.test.js
@@ -1,0 +1,222 @@
+import AltoMare from "../AltoMare/AltoMare.js"
+
+// Prerequisites
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(`Assertion failed: ${message}`);
+    }
+    return true;
+}
+
+function describe(suiteName, testFunction) {
+    console.log(`\n=== ${suiteName} ===`);
+    try {
+        testFunction();
+        console.log(`✓ ${suiteName} completed successfully`);
+    } catch (error) {
+        console.error(`✗ ${suiteName} failed:`, error.message);
+    }
+}
+
+function it(testName, testFunction) {
+    try {
+        testFunction();
+        console.log(`  ✓ ${testName}`);
+    } catch (error) {
+        console.error(`  ✗ ${testName}:`, error.message);
+    }
+}
+
+const altoMare = new AltoMare("test");
+
+function setupTestEnvironment() {
+    altoMare.registerValidator({
+        isEven: (value) => value % 2 === 0,
+        lettersOnly: (value) => /^[A-Za-z]+$/.test(value),
+        uniqueArray: (arr) => new Set(arr).size === arr.length,
+        isFutureDate: (value) => new Date(value) > new Date()
+    });
+
+    const templates = {
+        "baseUser": {
+            username: {
+                type: "string",
+                minLength: 3,
+                maxLength: 20,
+                pattern: "^[A-Za-z0-9_]+$"
+            },
+            email: {
+                type: "string",
+                pattern: "^[^@]+@[^@]+\\.[^@]+$"
+            }
+        }
+    };
+
+    altoMare.loadTemplates(JSON.stringify(templates));
+
+    altoMare.register("product", {
+        requiredProperties: ["id", "name", "price"],
+        id: {
+            type: "string",
+            pattern: "^PRD-\\d+$"
+        },
+        name: {
+            type: "string",
+            minLength: 2,
+            maxLength: 50
+        },
+        price: {
+            type: "number",
+            min: 0
+        },
+        tags: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            uniqueArray: true
+        }
+    });
+
+    altoMare.registerFromTemplate("premiumUser", "baseUser", {
+        subscriptionTier: {
+            type: "string",
+            enum: {
+                value: ["silver", "gold", "platinum"],
+                message: "Invalid subscription tier"
+            }
+        },
+        paymentDue: {
+            type: "string",
+            isFutureDate: {
+                value: true,
+                message: "Payment due date must be in the future"
+            }
+        }
+    });
+}
+
+function runTests() {
+    describe('Product Schema Validation', () => {
+        it('should validate a correct product', () => {
+            const validProduct = {
+                id: "PRD-123",
+                name: "Wireless Headphones",
+                price: 99.99,
+                tags: ["electronics", "audio"]
+            };
+            assert(
+                altoMare.validate("product", validProduct),
+                "Valid product should pass validation"
+            );
+        });
+
+        it('should reject invalid product ID format', () => {
+            const invalidProduct = {
+                id: "PROD123",
+                name: "Smart Watch",
+                price: 199.99,
+                tags: ["electronics"]
+            };
+            try {
+                altoMare.validate("product", invalidProduct);
+                assert(false, "Should have thrown validation error");
+            } catch (error) {
+                assert(true, "Invalid product ID correctly rejected");
+            }
+        });
+
+        it('should reject negative price', () => {
+            const invalidProduct = {
+                id: "PRD-124",
+                name: "Smart Watch",
+                price: -199.99,
+                tags: ["electronics"]
+            };
+            try {
+                altoMare.validate("product", invalidProduct);
+                assert(false, "Should have thrown validation error");
+            } catch (error) {
+                assert(true, "Negative price correctly rejected");
+            }
+        });
+    });
+
+    describe('Premium User Validation', () => {
+        it('should validate correct premium user', () => {
+            const validUser = {
+                username: "john_doe",
+                email: "john@example.com",
+                subscriptionTier: "gold",
+                paymentDue: "2024-12-31"
+            };
+            assert(
+                altoMare.validate("premiumUser", validUser),
+                "Valid premium user should pass validation"
+            );
+        });
+
+        it('should reject invalid subscription tier', () => {
+            const invalidUser = {
+                username: "jane_doe",
+                email: "jane@example.com",
+                subscriptionTier: "diamond",
+                paymentDue: "2024-12-31"
+            };
+            try {
+                altoMare.validate("premiumUser", invalidUser);
+                assert(false, "Should have thrown validation error");
+            } catch (error) {
+                assert(true, "Invalid subscription tier correctly rejected");
+            }
+        });
+
+        it('should reject past payment due date', () => {
+            const invalidUser = {
+                username: "bob_smith",
+                email: "bob@example.com",
+                subscriptionTier: "silver",
+                paymentDue: "2023-01-01"
+            };
+            try {
+                altoMare.validate("premiumUser", invalidUser);
+                assert(false, "Should have thrown validation error");
+            } catch (error) {
+                assert(true, "Past payment due date correctly rejected");
+            }
+        });
+    });
+
+    describe('Schema Management', () => {
+        it('should successfully unregister and reject subsequent validation', () => {
+            altoMare.unregister("product");
+            try {
+                altoMare.validate("product", {});
+                assert(false, "Should have thrown error after unregistration");
+            } catch (error) {
+                assert(true, "Unregistered schema correctly rejected");
+            }
+        });
+
+        it('should retrieve premium user schema', () => {
+            const schema = altoMare.get("premiumUser");
+            assert(
+                schema && schema.email && schema.subscriptionTier,
+                "Premium user schema should be retrievable"
+            );
+        });
+    });
+}
+
+function runAllTests() {
+    console.log("Starting AltoMare Test Suite...");
+    try {
+        setupTestEnvironment();
+        runTests();
+        console.log("\nTest suite completed successfully!");
+    } catch (error) {
+        console.error("\nTest suite failed:", error.message);
+    }
+}
+
+runAllTests();


### PR DESCRIPTION
The original version was quite crappy and didn't comply with SRP, to say the least. This new version also silently fails instead of derailing the entire application on a singular schema mismatch. Use `new AltoMare("debug")` to see the errors, `validate` will now return a boolean value of success. Oh ye, and I added the parameter validation that I forgot about.

Total time spent on this piece of shit comes to a total of 6 hours. I don't even wanna know what Sakura is going to be like. I got it done though, and I'm quite proud of it. 